### PR TITLE
kernel: large inbound frames dropped on drivers that deliver non-linear skbs (virtio_net)

### DIFF
--- a/kernel/dnet_nsp.c
+++ b/kernel/dnet_nsp.c
@@ -1183,11 +1183,12 @@ int dn_nsp_rcv(
                                 }
                         
                                 /*
-                                 * Linearize everything except data segments
+                                 * Linearize data segments too: dn_recvmsg()
+                                 * uses memcpy_to_msg() from skb->data and
+                                 * skb_pull(), which need linear data.
                                  */
-                                if ((flags & NSP_TYP_MASK) != NSP_TYP_DATA)
-                                        if (unlikely(skb_linearize(skb)))
-                                                goto drop;
+                                if (unlikely(skb_linearize(skb)))
+                                        goto drop;
                         
                                 /*
                                  * Look up socket

--- a/kernel/dnet_route.c
+++ b/kernel/dnet_route.c
@@ -192,7 +192,7 @@ int dn_routing_rcv(
 )
 {
         struct dn_skb_cb *cb = DN_SKB_CB(skb);
-        uint16_t len = le16_to_cpu(*(uint16_t *)skb->data);
+        uint16_t len;
         uint8_t flags = 0;
         uint8_t padlen = 0;
         
@@ -214,8 +214,18 @@ int dn_routing_rcv(
         if ((skb = skb_share_check(skb, GFP_ATOMIC)) == NULL)
                 goto out;
 
+        /* skb_share_check() may have returned a clone; cb must follow it. */
+        cb = DN_SKB_CB(skb);
+
         if ((dev == ETHDEVICE.dev) || (dev == LOOPDEVICE.dev)) {
                 if (pskb_may_pull(skb, 3)) {
+                        /*
+                         * Read the length only after pskb_may_pull(). Drivers
+                         * such as virtio_net deliver large frames with the
+                         * payload entirely in page fragments; reading
+                         * skb->data before the pull returned 0.
+                         */
+                        len = le16_to_cpu(*(uint16_t *)skb->data);
                         skb_pull(skb, sizeof(uint16_t));
 
                         if (len <= skb->len) {


### PR DESCRIPTION
Inbound transfers to Linux stalled above ~1 KB on a Debian 13 VM (kernel 6.12, virtio-net). Small files worked. The same code on a Raspberry Pi 4 did not show it.

**Cause**

- `dn_routing_rcv()` reads the 2-byte length field from `skb->data` before its `pskb_may_pull(skb, 3)`.
- virtio_net delivers large frames with only the MAC header linear and the payload in a page fragment. After `eth_type_trans()` the linear area is empty. A kprobe at function entry showed `len=1478 data_len=1478` for every dropped frame, `len=46 data_len=0` for the ones that worked.
- The read returns 0, the frame is trimmed to 0 bytes, and the padding check drops it. `skb:kfree_skb` placed every large frame at `dn_routing_rcv+0x76`.
- bcmgenet (Pi) always delivers linear skbs, so it never fires there.

**Change**

- `dnet_route.c`: read `len` after the `pskb_may_pull()`. Also recompute `cb` after `skb_share_check()`, which can return a clone; the old code wrote `cb->rt_flags` into the released buffer whenever tcpdump held a reference.
- `dnet_nsp.c`: linearize data segments too. With only the first change, a fragment-only data segment reaches `dn_recvmsg()`, whose `memcpy_to_msg(skb->data, …)` and `skb_pull()` need linear data, and `skb_pull()` will `BUG()`. A frag-aware `dn_recvmsg()` would avoid the copy; I left that choice to you.

**Tested**

- Debian 13, 6.12.107, x86_64, virtio-net, against OpenVMS Alpha 8.4 (`dncopy` both ways, VMS `COPY`).
- 448 B to 256 KB round trips byte-identical in both directions, with and without tcpdump attached.

**Not tested**

- Raspberry Pi / aarch64 after the change. Those skbs were already linear, so behaviour there should not change.
- Drivers other than virtio-net and bcmgenet.

Diagnosed and written by Claude (Fable 5) on my behalf; I tested it on my systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyMcbvQvnbSUdQN6NLR5Rm
